### PR TITLE
Fix ionic Sass import

### DIFF
--- a/app/index.scss
+++ b/app/index.scss
@@ -19,4 +19,4 @@ $dark:                            #444 !default;
 // The path for our ionicons font files, relative to the built CSS in www/css
 $ionicons-font-path: "../bower_components/ionic/fonts" !default;
 
-@import "ionic/scss/ionic";
+@import "~ionic/scss/ionic";


### PR DESCRIPTION
The tilde (`~`) prefix tells `sass-loader` to look-up the [modulesDirectories](http://webpack.github.io/docs/configuration.html#resolve-modulesdirectories).
