### PR TITLE
Removed noparse: bower_components

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,12 +54,7 @@ module.exports = {
     }, {
       test   : /[\/]ionic\.js$/,
       loader : 'exports?ionic'
-    }],
-
-    // NOTE: this helps build speed on larger libraries that do not use commonjs
-    noParse: [
-      /bower_components/
-    ]
+    }]
   },
 
   resolve: {


### PR DESCRIPTION
This gave me a lot of problems, because I wasn't able to load `css`/`@font-face` from `bower-components`.

I was having a lot of errors. See here: http://stackoverflow.com/questions/33733370/webpack-cannot-load-fonts-from-bower-using-css-scss/33752571#33752571
