### PR TITLE
updated cordova and ionic plugin location to new npm format and location

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ gulp watch
 Adding Cordova Plugins
 
 ```bash
-$ cordova plugins add com.ionic.keyboard org.apache.cordova.console org.apache.cordova.device
+$ cordova plugins add ionic-plugin-keyboard cordova-plugin-console cordova-plugin-device
 ```
 
 Adding Cordova Platforms


### PR DESCRIPTION
When following the install instructions, I got a couple errors and warnings about how cordova plugins have been moved to npm and now use a different format. 

I just updated the README to reflect the current format and location for these plugins. 
